### PR TITLE
Ignore renamed packages.

### DIFF
--- a/rolling.ignored
+++ b/rolling.ignored
@@ -1,1 +1,3 @@
 gz_ros2_control_tests
+ign_ros2_control
+ign_ros2_control_demos


### PR DESCRIPTION
Internal steps in the bloom release process use pattern matching on available branch names to detect which packages to generate release metadata for.

To prevent this from happening when a package within the repository is renamed either of the following will work:

* the old package names need to be added to the ignored file
* the `release/`, `rpm/`, and `debian/` branches for the old package names need to be deleted. Branches are only used for bloom runtime. All downstream consumption of package data uses tags and it's not necessary to preserve the branch a tag was created from when keeping the tag.